### PR TITLE
Fix typo that broke Docker build

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,3 +1,3 @@
 FROM arangodb:latest
 
-COPY _init_db_tmp.js /docker-entrypoint-initdb.d/
+COPY _init_db.js /docker-entrypoint-initdb.d/


### PR DESCRIPTION
There is a typo in the Dockerfile that breaks the build of the docker images.