### PR TITLE
Override OpenSSL version

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -2,6 +2,8 @@ FROM node:latest as build-stage
 
 ARG HOST=http://localhost:8080
 
+ENV NODE_OPTIONS=--openssl-legacy-provider
+
 WORKDIR /app
 COPY package*.json ./
 


### PR DESCRIPTION
Use legacy instead of 3.0: https://github.com/vuejs/vue-cli/issues/6770#issuecomment-961307401
